### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ to `/opt/stackstorm/configs/hubot.yaml` and edit as required.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * `branch`       - List the current deployed git branch of Hubot.

--- a/actions/post_message.yaml
+++ b/actions/post_message.yaml
@@ -1,6 +1,6 @@
 ---
   name: "post_message"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Post a message to Hubot"
   enabled: true
   entry_point: "post_message.py"

--- a/actions/post_result.py
+++ b/actions/post_result.py
@@ -131,7 +131,7 @@ FORMATTERS = {
     # actionchainrunner
     'action-chain': format_actionchain_result,
     # pythonrunner
-    'python-script': format_pythonrunner_result,
+    'run-python': format_pythonrunner_result,
     'python-script': format_pythonrunner_result,
     # windowsrunner
     'windows-cmd': format_windowsrunner_result,

--- a/actions/post_result.py
+++ b/actions/post_result.py
@@ -131,7 +131,7 @@ FORMATTERS = {
     # actionchainrunner
     'action-chain': format_actionchain_result,
     # pythonrunner
-    'run-python': format_pythonrunner_result,
+    'python-script': format_pythonrunner_result,
     'python-script': format_pythonrunner_result,
     # windowsrunner
     'windows-cmd': format_windowsrunner_result,

--- a/actions/post_result.yaml
+++ b/actions/post_result.yaml
@@ -1,7 +1,7 @@
 ---
   name: "post_result"
   pack: hubot
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Post an execution result to Hubot"
   enabled: true
   entry_point: "post_result.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: hubot
 name: hubot
 description: Hubot integration pack
-version: 0.2.0
+version: 0.3.0
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.