### PR TITLE
Remove 'this' ambiguity and point out the Actions section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # WARNING!
 
-> Most people do not need this pack. If you want to use ChatOps with StackStorm, use the st2chatops package. This is installed by default with StackStorm.
-> It includes Hubot, wired up to StackStorm.
-> See docs.stackstorm.com/chatops/index.html for more about how to configure ChatOps.
-> Only install this pack if you are really sure you need it.
+Most people do not need this pack. If you want to use ChatOps with StackStorm, use the st2chatops package, which is installed by default with StackStorm.
+The chatops pack (st2chatops package) includes Hubot, already wired up to StackStorm.
+See docs.stackstorm.com/chatops/index.html for more about how to configure ChatOps.
+
+Only install this pack if you are _really_ sure that you need it. See the [Actions section](#actions) to see if this pack is useful for you.
 
 # Hubot Integration Pack
 


### PR DESCRIPTION
This PR makes things a bit clearer for uninitiated users.