### PR TITLE
Remove requests pinning, remove use of httplib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Remove requests version restriction, remove use of httplib
+
 # 0.3.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/actions/post_message.py
+++ b/actions/post_message.py
@@ -1,5 +1,4 @@
 import json
-import httplib
 import requests
 from six.moves.urllib.parse import urljoin
 
@@ -35,7 +34,7 @@ class PostMessageAction(Action):
         data = json.dumps(body)
         response = requests.post(url=url, headers=headers, data=data)
 
-        if response.status_code == httplib.OK:
+        if response.status_code == requests.codes.ok: # pylint: disable=no-member
             self.logger.info('Message successfully posted')
         else:
             self.logger.exception('Failed to post message: %s' % (response.text))

--- a/actions/post_message.py
+++ b/actions/post_message.py
@@ -34,7 +34,7 @@ class PostMessageAction(Action):
         data = json.dumps(body)
         response = requests.post(url=url, headers=headers, data=data)
 
-        if response.status_code == requests.codes.ok: # pylint: disable=no-member
+        if response.status_code == requests.codes.ok:  # pylint: disable=no-member
             self.logger.info('Message successfully posted')
         else:
             self.logger.exception('Failed to post message: %s' % (response.text))

--- a/actions/post_result.py
+++ b/actions/post_result.py
@@ -1,5 +1,4 @@
 import json
-import httplib
 import requests
 import six
 from six.moves.urllib.parse import urljoin
@@ -165,7 +164,7 @@ class PostResultAction(Action):
         self.logger.info(data)
         response = requests.post(url=url, headers=headers, data=data)
 
-        if response.status_code == httplib.OK:
+        if response.status_code == requests.codes.ok: # pylint: disable=no-member
             self.logger.info('Message successfully posted')
         else:
             self.logger.exception('Failed to post message: %s' % (response.text))

--- a/actions/post_result.py
+++ b/actions/post_result.py
@@ -168,7 +168,7 @@ class PostResultAction(Action):
         self.logger.info(data)
         response = requests.post(url=url, headers=headers, data=data)
 
-        if response.status_code == requests.codes.ok: # pylint: disable=no-member
+        if response.status_code == requests.codes.ok:  # pylint: disable=no-member
             self.logger.info('Message successfully posted')
         else:
             self.logger.exception('Failed to post message: %s' % (response.text))

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: hubot
 name: hubot
 description: Hubot integration pack
-version: 0.3.1
+version: 0.4.0
 author: James Fryman
 email: james@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests>=2.5.1,<2.6
+requests
 six


### PR DESCRIPTION
Requests was pinned to older version with known vulnerabilities. No specific reason to pin to older version. 

Also removed `httplib` - that usage could be handled by `requests()`.